### PR TITLE
Add try/except to continue on invalid pdf.

### DIFF
--- a/SmeegeScrape.py
+++ b/SmeegeScrape.py
@@ -67,8 +67,12 @@ args = parser.parse_args()
 #PyPDF2 does not always work very well with extracting text from pdf.  It mainly depends on how the PDF was generated.                
 def getPDFContent(path):
     # Load PDF into PyPDF2
-    pdf = PyPDF2.PdfFileReader(file(path, "rb"))
-
+    try:
+	    pdf = PyPDF2.PdfFileReader(file(path, "rb"))
+    except:
+    	print 'Error reading: ' + path + '. Skipping.'
+    	return
+    	
     if pdf.isEncrypted:
         print 'pdf ' + path + ' is encrypted, trying blank password...'
         pdf.decrypt('') #If you want to provide your own password for an encrypted pdf, modify code here.


### PR DESCRIPTION
Hello,

I patched SmeegeScape.py to manage invalid pdf and continue instead of crash.
Here an example of output:

```bash
root@kali2:SmeegeScrape# ./SmeegeScrape.py -d /path/ -r
...

Scraping Files in Local Directory (recursively) - /path/
Error reading: /media/sf_SSI/ressources/phablet/CEHv9/CEHv9_Invalid.pdf. Skipping.

0 unique words have been scraped.
Output file successfully written: smeegescrape_out.txt
root@kali2:SmeegeScrape#
```

Regards,
fraf.